### PR TITLE
Fix a slow teardown issue

### DIFF
--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -53,6 +53,7 @@ def setup_db() -> Generator:
     except SQLAlchemyError:
         pass
     conn.close()
+    engine.dispose()
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -64,6 +65,8 @@ def setup_test_db(setup_db: Generator) -> Generator:
         Base.metadata.create_all(engine)
         yield
         Base.metadata.drop_all(engine)
+
+    engine.dispose()
 
 
 @pytest.fixture
@@ -101,3 +104,5 @@ async def session() -> AsyncGenerator:
         yield async_session
         await async_session.close()
         await conn.rollback()
+
+    await async_engine.dispose()


### PR DESCRIPTION
fixes #6 .

## Before( = current main branch)

```bash
(venv) $ time pytest -q --no-cov app
====================================================================================================== test session starts =======================================================================================================
platform darwin -- Python 3.11.5, pytest-7.4.0, pluggy-1.3.0
Using --randomly-seed=3566254953
rootdir: /Users/rhoboro/go/src/github.com/rhoboro/async-fastapi-sqlalchemy
configfile: pyproject.toml
plugins: anyio-4.0.0, env-1.0.1, randomly-3.15.0, cov-4.1.0, mock-3.11.1
collected 11 items

app/tests/api/notes/test_views.py .....                                                                                                                                                                                    [ 45%]
app/tests/test_main.py .                                                                                                                                                                                                   [ 54%]
app/tests/api/notebooks/test_views.py .....                                                                                                                                                                                [100%]

======================================================================================================= 11 passed in 6.75s =======================================================================================================
pytest -q --no-cov app  0.86s user 0.10s system 13% cpu 7.379 total
```

## After (= this branch)

About 5 seconds faster.

```bash
$ time pytest -q --no-cov app
====================================================================================================== test session starts =======================================================================================================
platform darwin -- Python 3.11.5, pytest-7.4.0, pluggy-1.3.0
Using --randomly-seed=1407174434
rootdir: /Users/rhoboro/go/src/github.com/rhoboro/async-fastapi-sqlalchemy
configfile: pyproject.toml
plugins: anyio-4.0.0, env-1.0.1, randomly-3.15.0, cov-4.1.0, mock-3.11.1
collected 11 items

app/tests/test_main.py .                                                                                                                                                                                                   [  9%]
app/tests/api/notes/test_views.py .....                                                                                                                                                                                    [ 54%]
app/tests/api/notebooks/test_views.py .....                                                                                                                                                                                [100%]

======================================================================================================= 11 passed in 1.79s =======================================================================================================
pytest -q --no-cov app  0.85s user 0.10s system 39% cpu 2.414 total
```